### PR TITLE
Discard and report APNS DeviceTokenNotForTopic errors

### DIFF
--- a/app/jobs/action_native_push/notification_delivery_job.rb
+++ b/app/jobs/action_native_push/notification_delivery_job.rb
@@ -7,6 +7,9 @@ module ActionNativePush
     self.log_arguments = ActionNativePush.log_job_arguments
 
     discard_on ActiveJob::DeserializationError
+    discard_on Errors::BadDeviceTopicError do |_job, error|
+      Rails.error.report(error)
+    end
 
     class << self
       def retry_options

--- a/lib/action_native_push/errors.rb
+++ b/lib/action_native_push/errors.rb
@@ -3,6 +3,7 @@
 module ActionNativePush::Errors
   class TimeoutError < StandardError; end
   class BadRequestError < StandardError; end
+  class BadDeviceTopicError < BadRequestError; end
   class ConnectionError < StandardError; end
   class TokenError < StandardError; end
   class DeviceTokenError < TokenError; end

--- a/lib/action_native_push/service/apns.rb
+++ b/lib/action_native_push/service/apns.rb
@@ -100,6 +100,8 @@ module ActionNativePush
             raise ActionNativePush::Errors::TimeoutError
           in [ "400", "BadDeviceToken" ]
             raise ActionNativePush::Errors::DeviceTokenError, reason
+          in [ "400", "DeviceTokenNotForTopic" ]
+            raise ActionNativePush::Errors::BadDeviceTopicError, reason
           in [ "400", _ ]
             raise ActionNativePush::Errors::BadRequestError, reason
           in [ "403", _ ]


### PR DESCRIPTION
This happens when the device token is valid but for a different topic. Deleting the device won't work in this case because the reissued token will still be wrong. For now, discard these errors and report them.