### PR TITLE
FCM: HTTP persistent connections with HTTPX

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,6 @@ PATH
       googleauth (~> 1.14)
       httpx (~> 1.6)
       jwt (>= 2)
-      net-http (~> 0.6)
       railties (>= 8.0)
 
 GEM

--- a/action_push_native.gemspec
+++ b/action_push_native.gemspec
@@ -38,5 +38,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "httpx", "~> 1.6"
   spec.add_dependency "jwt", ">= 2"
   spec.add_dependency "googleauth", "~> 1.14"
-  spec.add_dependency "net-http", "~> 0.6"
 end

--- a/lib/action_push_native.rb
+++ b/lib/action_push_native.rb
@@ -3,7 +3,6 @@
 require "zeitwerk"
 require "action_push_native/engine"
 require "action_push_native/errors"
-require "net/http"
 require "httpx"
 require "googleauth"
 require "jwt"

--- a/lib/action_push_native/service/network_error_handling.rb
+++ b/lib/action_push_native/service/network_error_handling.rb
@@ -1,0 +1,20 @@
+module ActionPushNative::Service::NetworkErrorHandling
+  private
+
+  def handle_network_error(error)
+    case error
+    when Errno::ETIMEDOUT, HTTPX::TimeoutError
+      raise ActionPushNative::TimeoutError, error.message
+    when Errno::ECONNRESET, Errno::ECONNABORTED, Errno::ECONNREFUSED, Errno::EHOSTUNREACH,
+      SocketError, IOError, EOFError, Errno::EPIPE, Errno::EINVAL, HTTPX::ConnectionError,
+      HTTPX::TLSError, HTTPX::Connection::HTTP2::Error
+      raise ActionPushNative::ConnectionError, error.message
+    when OpenSSL::SSL::SSLError
+      if error.message.include?("SSL_connect")
+        raise ActionPushNative::ConnectionError, error.message
+      else
+        raise
+      end
+    end
+  end
+end

--- a/lib/generators/action_push_native/install/templates/config/push.yml.tt
+++ b/lib/generators/action_push_native/install/templates/config/push.yml.tt
@@ -32,5 +32,9 @@ shared:
     # Firebase project_id
     project_id: your_project_id
 
+    # Set this to the number of threads used to process notifications (default: 5).
+    # When the pool size is too small a HTTPX::PoolTimeoutError error will be raised.
+    # connection_pool_size: 5
+
     # Change the request timeout (default: 15).
     # request_timeout: 30

--- a/test/dummy/config/push.yml
+++ b/test/dummy/config/push.yml
@@ -29,6 +29,10 @@ shared:
     # See https://firebase.google.com/docs/cloud-messaging/auth-server
     encryption_key: <%= Rails.application.credentials.dig(:action_push_native, :fcm, :encryption_key) %>
 
+    # Set this to the number of threads used to process notifications (default: 5).
+    # When the pool size is too small a HTTPX::PoolTimeoutError error will be raised.
+    # connection_pool_size: 5
+
     # Firebase project_id
     project_id: your_project_id
 

--- a/test/jobs/action_push_native/notification_job_test.rb
+++ b/test/jobs/action_push_native/notification_job_test.rb
@@ -36,7 +36,8 @@ module ActionPushNative
 
     test "Socket errors are retried" do
       device = action_push_native_devices(:pixel9)
-      Net::HTTP.any_instance.stubs(:request).raises(SocketError)
+      stub_request(:post, "https://fcm.googleapis.com/v1/projects/your_project_id/messages:send").
+        to_raise(SocketError.new)
       ActionPushNative::Service::Fcm.any_instance.stubs(:access_token).returns("fake_access_token")
 
       assert_enqueued_jobs 1, only: ActionPushNative::NotificationJob do

--- a/test/lib/action_push_native/service/fcm_test.rb
+++ b/test/lib/action_push_native/service/fcm_test.rb
@@ -49,7 +49,14 @@ module ActionPushNative
           @fcm.push(@notification)
         end
 
-        Net::HTTP.stubs(:start).raises(OpenSSL::SSL::SSLError.new("SSL_connect returned=1 errno=0 state=error"))
+        stub_request(:post, "https://fcm.googleapis.com/v1/projects/your_project_id/messages:send").
+          to_return(status: 500, body: "Not a JSON")
+        assert_raises ActionPushNative::InternalServerError do
+          @fcm.push(@notification)
+        end
+
+        stub_request(:post, "https://fcm.googleapis.com/v1/projects/your_project_id/messages:send").
+          to_raise(OpenSSL::SSL::SSLError.new("SSL_connect returned=1 errno=0 state=error"))
         assert_raises ActionPushNative::ConnectionError do
           @fcm.push(@notification)
         end


### PR DESCRIPTION
As a result of this change, FCM connections now also make use of a connection pool. Accordingly, a configuration option, similar to the one used for APNs, has been introduced.