### PR TITLE
Cache FCM acces_token until expiration

### DIFF
--- a/lib/action_push_native/service/fcm/httpx_session.rb
+++ b/lib/action_push_native/service/fcm/httpx_session.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ActionPushNative::Service::Fcm::HttpxSession
+  # FCM suggests at least a 10s timeout for requests, we set 15 to add some buffer.
+  # https://firebase.google.com/docs/cloud-messaging/scale-fcm#timeouts
+  DEFAULT_REQUEST_TIMEOUT = 15.seconds
+  DEFAULT_POOL_SIZE       = 5
+
+  def initialize(config)
+    @session = \
+      HTTPX.
+        plugin(:persistent, close_on_fork: true).
+        with(timeout: { request_timeout: config[:request_timeout] || DEFAULT_REQUEST_TIMEOUT }).
+        with(pool_options: { max_connections: config[:connection_pool_size] || DEFAULT_POOL_SIZE }).
+        with(origin: "https://fcm.googleapis.com")
+    @token_provider = ActionPushNative::Service::Fcm::TokenProvider.new(config)
+  end
+
+  def post(*uri, **options)
+    options[:headers] ||= {}
+    options[:headers][:authorization] = "Bearer #{token_provider.fresh_access_token}"
+    session.post(*uri, **options)
+  end
+
+  private
+    attr_reader :token_provider, :session
+end

--- a/lib/action_push_native/service/fcm/token_provider.rb
+++ b/lib/action_push_native/service/fcm/token_provider.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class ActionPushNative::Service::Fcm::TokenProvider
+  EXPIRED = -1
+
+  def initialize(config)
+    @config = config
+    @expires_at = EXPIRED
+  end
+
+  def fresh_access_token
+    regenerate_if_expired
+    token
+  end
+
+  private
+    attr_reader :config, :token, :expires_at
+
+    def regenerate_if_expired
+      regenerate if Time.now.utc >= expires_at
+    end
+
+    REFRESH_BUFFER = 1.minutes
+
+    def regenerate
+      authorizer = Google::Auth::ServiceAccountCredentials.make_creds \
+        json_key_io: StringIO.new(config.fetch(:encryption_key)),
+        scope: "https://www.googleapis.com/auth/firebase.messaging"
+      oauth2 = authorizer.fetch_access_token!
+      @token = oauth2["access_token"]
+      @expires_at = oauth2["expires_in"].seconds.from_now.utc - REFRESH_BUFFER
+    end
+end

--- a/test/jobs/action_push_native/notification_job_test.rb
+++ b/test/jobs/action_push_native/notification_job_test.rb
@@ -38,7 +38,9 @@ module ActionPushNative
       device = action_push_native_devices(:pixel9)
       stub_request(:post, "https://fcm.googleapis.com/v1/projects/your_project_id/messages:send").
         to_raise(SocketError.new)
-      ActionPushNative::Service::Fcm.any_instance.stubs(:access_token).returns("fake_access_token")
+      authorizer = stub("authorizer")
+      authorizer.stubs(:fetch_access_token!).returns({ "access_token" => "fake_access_token", "expires_in" => 3599 })
+      Google::Auth::ServiceAccountCredentials.stubs(:make_creds).returns(authorizer)
 
       assert_enqueued_jobs 1, only: ActionPushNative::NotificationJob do
         ActionPushNative::NotificationJob.perform_later("ApplicationPushNotification", @notification_attributes, device)


### PR DESCRIPTION
Retrieving the Auth tokens is the slowest part of the notification process. Caching tokens will give a huge performance boost.