### PR TITLE
Fix ERB syntax for development server connection

### DIFF
--- a/lib/generators/action_push_native/install/templates/config/push.yml.tt
+++ b/lib/generators/action_push_native/install/templates/config/push.yml.tt
@@ -21,7 +21,7 @@ shared:
     # Please note that anything built directly from Xcode and loaded on your phone will have
     # the app generate DEVELOPMENT tokens, while everything else (TestFlight, Apple Store, ...)
     # will be considered as PRODUCTION environment.
-    # connect_to_development_server: <%%# Rails.env.development? %>
+    # connect_to_development_server: <%%= Rails.env.development? %>
 
   # Use bin/rails credentials:edit to set the fcm secrets (as action_push_native:fcm:encryption_key)
   google:


### PR DESCRIPTION
When uncommenting the line (at the first hash), one would expect `connect_to_development_server` to reflect the result of `Rails.env.development?`, unless catching that the intended echo statement later in the same line was _also_ commented out. For the expected behavior, the `<%#` needs to also be uncommented as `<%=`, which is easy to miss and difficult to debug.

Fixes #54.