### PR TITLE
Fix OpenSSL::PKey::EC.new compatibility with openssl gem 3.0+

### DIFF
--- a/lib/action_push_native/service/apns/token_provider.rb
+++ b/lib/action_push_native/service/apns/token_provider.rb
@@ -27,7 +27,7 @@ class ActionPushNative::Service::Apns::TokenProvider
     def generate
       payload = { iss: config.fetch(:team_id), iat: Time.now.utc.to_i }
       header  = { kid: config.fetch(:key_id) }
-      private_key = OpenSSL::PKey::EC.new(config.fetch(:encryption_key))
+      private_key = OpenSSL::PKey.read(config.fetch(:encryption_key))
       JWT.encode(payload, private_key, "ES256", header)
     end
 end

--- a/test/lib/action_push_native/service/apns_test.rb
+++ b/test/lib/action_push_native/service/apns_test.rb
@@ -179,6 +179,20 @@ module ActionPushNative
         end
       end
 
+      test "generate produces a valid ES256 JWT from a PEM key" do
+        ActionPushNative::Service::Apns::TokenProvider.any_instance.unstub(:fresh_access_token)
+
+        ec_key = OpenSSL::PKey::EC.generate("prime256v1")
+        config = { team_id: "TEAM123", key_id: "KEY456", encryption_key: ec_key.to_pem }
+        provider = ActionPushNative::Service::Apns::TokenProvider.new(config)
+
+        token = provider.fresh_access_token
+
+        decoded = JWT.decode(token, ec_key, true, algorithm: "ES256")
+        assert_equal "TEAM123", decoded.first["iss"]
+        assert_equal "KEY456", decoded.last["kid"]
+      end
+
       test "connect to APNs development server" do
         apns = Apns.new(@config.merge(connect_to_development_server: true))
         stub_request(:post, "https://api.sandbox.push.apple.com/3/device/123").to_return(status: 200)


### PR DESCRIPTION

<img width="743" height="192" alt="Screenshot 2026-03-26 at 11 13 12" src="https://github.com/user-attachments/assets/ffda52ce-aa2e-4db4-9d95-94e8478dad12" />


## Summary

- `OpenSSL::PKey::EC.new(pem_string)` no longer accepts PEM/DER key strings since the `openssl` gem 3.0 (Ruby 3.2+). It now only accepts curve names (e.g., `"prime256v1"`), causing `OpenSSL::PKey::PKeyError: invalid curve name` when generating APNs JWT tokens.
- Replace with `OpenSSL::PKey.read(pem_string)`, which handles PEM/DER formats and is backwards-compatible with older Ruby versions.

## Test plan

- [ ] Verified push notifications deliver successfully on staging with Ruby 4.0.2 / openssl gem 4.0.1
- [ ] Existing test suite passes (`access tokens are refreshed every 30 minutes` test covers the token generation flow)

Fixes #118