### PR TITLE
Add a unique index on action_push_native_devices.token

### DIFF
--- a/db/migrate/20260708120000_add_unique_index_to_action_push_native_devices_token.rb
+++ b/db/migrate/20260708120000_add_unique_index_to_action_push_native_devices_token.rb
@@ -1,0 +1,37 @@
+class AddUniqueIndexToActionPushNativeDevicesToken < ActiveRecord::Migration[7.2]
+  # A device is identified by its push token, so two rows sharing a token
+  # deliver duplicate notifications (delivery sends once per device row). Apps
+  # that register tokens with find_or_create_by(token:) can also race concurrent
+  # registrations into duplicate rows — Hotwire Native re-sends the token on
+  # nearly every navigation, once per WebView — so the constraint belongs at the
+  # database. Shipped as an additive migration (rather than amending the
+  # create-table migration) so existing installs pick it up via
+  # `bin/rails action_push_native:install:migrations`.
+  def up
+    remove_duplicate_tokens
+    add_index :action_push_native_devices, :token, unique: true
+  end
+
+  def down
+    remove_index :action_push_native_devices, :token
+  end
+
+  private
+    # Keep one row per token (the highest id — i.e. the most recently inserted)
+    # and drop the rest; the unique index cannot build while duplicates remain.
+    # The removed rows are exact duplicates that were only ever causing
+    # duplicate deliveries. The derived-table wrapper keeps this portable across
+    # PostgreSQL, MySQL, and SQLite.
+    def remove_duplicate_tokens
+      execute(<<~SQL)
+        DELETE FROM action_push_native_devices
+        WHERE id NOT IN (
+          SELECT keep_id FROM (
+            SELECT MAX(id) AS keep_id
+            FROM action_push_native_devices
+            GROUP BY token
+          ) AS keepers
+        )
+      SQL
+    end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_10_075650) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_08_120000) do
   create_table "action_push_native_devices", force: :cascade do |t|
     t.string "name"
     t.string "platform", null: false
@@ -20,5 +20,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_075650) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["owner_type", "owner_id"], name: "index_action_push_native_devices_on_owner"
+    t.index ["token"], name: "index_action_push_native_devices_on_token", unique: true
   end
 end

--- a/test/fixtures/application_push_devices.yml
+++ b/test/fixtures/application_push_devices.yml
@@ -1,4 +1,4 @@
 iphone_6:
   name: iPhone 6
-  token: 7bf61218414641979cfdeded6c3c38a036033158945f9675576ff5dbbdbab17b
+  token: 9f8e7d6c5b4a39281706f5e4d3c2b1a09f8e7d6c5b4a39281706f5e4d3c2b1a0
   platform: apple

--- a/test/models/action_push_native/device_test.rb
+++ b/test/models/action_push_native/device_test.rb
@@ -37,5 +37,13 @@ module ActionPushNative
       end
       assert iphone.destroyed?
     end
+
+    test "token is unique across devices" do
+      ActionPushNative::Device.create!(token: "shared-token", platform: "apple")
+
+      assert_raises ActiveRecord::RecordNotUnique do
+        ActionPushNative::Device.create!(token: "shared-token", platform: "google")
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi! I was coding a Hotwire Native app and my agent came across something that it thinks it's a bug on `action_push_native`

My Android app was sending Rails the push token multiple times (on each screen load, apparently), which made Rails register those as different Android devices (one device per token pushed) -- which resulted in notifications being sent `n` times to each device instead of just 1.

We added a unique index on the device token and the problem got solved Rails-side, the Android side would need work too to avoid sending the token on each screen view, but this makes the server resilient to client bugs.

Here's what Claude Code (Opus 4.8) wrote for this PR. I'm happy to look into anything if it needs any extra work, I'm just writing this so you know there's a real human behind the agent.

---

## Why

A device is identified by its push token, so two rows sharing a token is a contradiction — and in practice it produces **duplicate notifications**, because delivery sends once per device row.

This is easy to hit with the usual registration flow: apps POST their push token to the server on launch/foreground and upsert it. Hotwire Native apps re-send on nearly every navigation, and each tab runs in its own WebView, so a fresh install's *first* registration fires several **concurrent** POSTs carrying the same token. With no unique index, the natural `find_or_initialize_by(token:)` / `find_or_create_by(token:)` each find nothing and `INSERT` — creating duplicate device rows, after which the user receives N copies of every push.

I ran into exactly this on a production app: one device registered **3 identical-token rows in the same second → 3 duplicate notifications**. A database-level unique constraint is the real fix — it also lets apps use `create_or_find_by(token:)` to collapse the concurrent race onto a single row.

## Changes

- **`db/migrate/20260708120000_add_unique_index_to_action_push_native_devices_token.rb`** (new) — adds the unique index. Shipped as an **additive** migration (rather than amending the released create-table migration) so existing installs pick it up via `bin/rails action_push_native:install:migrations`. It de-duplicates first — keeping one row per token — because the index can't build on an already-duplicated table; the removed rows are exact duplicates that were only ever causing duplicate deliveries. The dedup SQL is portable across PostgreSQL, MySQL, and SQLite.
- `test/dummy/db/schema.rb` — reflects the new index.
- `test/fixtures/application_push_devices.yml` — one fixture shared a token with `action_push_native/devices.yml` (both load into the same table); gave it a distinct token so fixtures load under the index. They were a latent duplicate — exactly what the index forbids.
- `test/models/action_push_native/device_test.rb` — asserts a duplicate token is rejected.

`bin/rails test` → 35 runs, 0 failures. `bin/rubocop` → clean.

## Notes

- The create-table migration is left untouched — this is purely additive.
- The dedup step deletes duplicate device rows (keeping the newest per token). If you'd prefer a non-destructive approach (e.g. raise and let the app dedup), I'm happy to change it.

---
Opened by Claude (Anthropic's Claude Code). Javi (@rameerez) asked me to upstream this after we hit the duplicate-notification bug above on a production app. Happy to adjust anything to fit the project's conventions.