### PR TITLE
Structured provider errors, push instrumentation, and Retry-After-aware retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,9 @@ end
 
 Network errors keep the original exception as `error.cause`.
 
+The delivery job's retry ladder honors `retry_after` as a floor: retries
+still back off exponentially, but never sooner than the provider asked.
+
 ### Instrumentation
 
 Each provider round trip, token refresh included, emits a

--- a/README.md
+++ b/README.md
@@ -300,6 +300,35 @@ class CustomDevice
 end
 ```
 
+### Structured errors
+
+Every error descends from `ActionPushNative::Error`. Errors raised from a
+provider response carry the context of that response:
+
+```ruby
+rescue ActionPushNative::TooManyRequestsError => error
+  error.service     # :apns or :fcm
+  error.status      # APNs: HTTP status (429); FCM: google.rpc status token ("RESOURCE_EXHAUSTED")
+  error.reason      # APNs: reason token ("TooManyRequests"); FCM: ErrorInfo reason ("QUOTA_EXCEEDED")
+  error.retry_after # provider-mandated wait, in seconds, when the response carried Retry-After
+end
+```
+
+Network errors keep the original exception as `error.cause`.
+
+### Instrumentation
+
+Each provider round trip, token refresh included, emits a
+`push.action_push_native` Active Support notification with `service:` and
+`device_token:` in the payload. When the provider errors, the payload also
+carries `status:`, `reason:`, `retry_after:`, and `exception_object:`.
+
+```ruby
+ActiveSupport::Notifications.subscribe "push.action_push_native" do |event|
+  StatsD.measure "push.#{event.payload[:service]}", event.duration
+end
+```
+
 ## `ActionPushNative::Notification` attributes
 
 | Name           | Description

--- a/app/jobs/action_push_native/notification_job.rb
+++ b/app/jobs/action_push_native/notification_job.rb
@@ -54,5 +54,16 @@ module ActionPushNative
     def perform(notification_class, notification_attributes, device)
       notification_class.constantize.new(**notification_attributes).deliver_to(device)
     end
+
+    # A provider-mandated Retry-After floors the backoff: the ladder still
+    # stretches waits exponentially, but never schedules a retry sooner
+    # than the provider asked.
+    def retry_job(options = {})
+      if retry_after = options[:error].try(:retry_after)
+        options = options.merge(wait: [ retry_after, options[:wait] ].compact.max)
+      end
+
+      super(options)
+    end
   end
 end

--- a/lib/action_push_native/errors.rb
+++ b/lib/action_push_native/errors.rb
@@ -1,18 +1,50 @@
 # frozen_string_literal: true
 
+require "time"
+
 module ActionPushNative
-  class TimeoutError < StandardError; end
-  class ConnectionError < StandardError; end
-  class ConnectionPoolTimeoutError < StandardError; end
+  # Base class for Action Push Native errors. Errors raised from a provider
+  # response carry structured context: the service that answered, the
+  # provider's status and reason tokens, and any Retry-After it mandated.
+  class Error < StandardError
+    attr_reader :service, :status, :reason, :retry_after
 
-  class BadRequestError < StandardError; end
-  class ForbiddenError < StandardError; end
-  class PayloadTooLargeError < StandardError; end
-  class TooManyRequestsError < StandardError; end
-  class ServiceUnavailableError < StandardError; end
-  class InternalServerError < StandardError; end
-  class BadDeviceTopicError < StandardError; end
-  class NotFoundError < StandardError; end
+    def initialize(message = nil, service: nil, status: nil, reason: nil, retry_after: nil)
+      @service = service
+      @status = status
+      @reason = reason
+      @retry_after = retry_after_in_seconds(retry_after)
+      super(message || reason)
+    end
 
-  class TokenError < StandardError; end
+    private
+      # Retry-After arrives as delta-seconds or an HTTP-date (RFC 9110 §10.2.3).
+      def retry_after_in_seconds(value)
+        case value
+        when nil, Numeric
+          value
+        when /\A\d+\z/
+          Integer(value)
+        else
+          [ Time.httpdate(value.to_s) - Time.now, 0 ].max
+        end
+      rescue ArgumentError
+        nil
+      end
+  end
+
+  class TimeoutError < Error; end
+  class ConnectionError < Error; end
+  class ConnectionPoolTimeoutError < Error; end
+
+  class BadRequestError < Error; end
+  class ForbiddenError < Error; end
+  class PayloadTooLargeError < Error; end
+  class TooManyRequestsError < Error; end
+  class ServiceUnavailableError < Error; end
+  class InternalServerError < Error; end
+  class BadDeviceTopicError < Error; end
+  class NotFoundError < Error; end
+
+  class TokenError < Error; end
 end

--- a/lib/action_push_native/service/apns.rb
+++ b/lib/action_push_native/service/apns.rb
@@ -4,6 +4,7 @@ module ActionPushNative
   module Service
     class Apns
       include NetworkErrorHandling
+      prepend Instrumentation
 
       def initialize(config)
         @config = config

--- a/lib/action_push_native/service/apns.rb
+++ b/lib/action_push_native/service/apns.rb
@@ -77,28 +77,32 @@ module ActionPushNative
 
           Rails.logger.error("APNs response error #{status}: #{reason}") if reason
 
-          case [ status, reason ]
-          in [ 400, "BadDeviceToken" ]
-            raise ActionPushNative::TokenError, reason
-          in [ 400, "DeviceTokenNotForTopic" ]
-            raise ActionPushNative::BadDeviceTopicError, reason
-          in [ 400, _ ]
-            raise ActionPushNative::BadRequestError, reason
-          in [ 403, _ ]
-            raise ActionPushNative::ForbiddenError, reason
-          in [ 404, _ ]
-            raise ActionPushNative::NotFoundError, reason
-          in [ 410, _ ]
-            raise ActionPushNative::TokenError, reason
-          in [ 413, _ ]
-            raise ActionPushNative::PayloadTooLargeError, reason
-          in [ 429, _ ]
-            raise ActionPushNative::TooManyRequestsError, reason
-          in [ 503, _ ]
-            raise ActionPushNative::ServiceUnavailableError, reason
-          else
-            raise ActionPushNative::InternalServerError, reason
-          end
+          error_class = \
+            case [ status, reason ]
+            in [ 400, "BadDeviceToken" ]
+              ActionPushNative::TokenError
+            in [ 400, "DeviceTokenNotForTopic" ]
+              ActionPushNative::BadDeviceTopicError
+            in [ 400, _ ]
+              ActionPushNative::BadRequestError
+            in [ 403, _ ]
+              ActionPushNative::ForbiddenError
+            in [ 404, _ ]
+              ActionPushNative::NotFoundError
+            in [ 410, _ ]
+              ActionPushNative::TokenError
+            in [ 413, _ ]
+              ActionPushNative::PayloadTooLargeError
+            in [ 429, _ ]
+              ActionPushNative::TooManyRequestsError
+            in [ 503, _ ]
+              ActionPushNative::ServiceUnavailableError
+            else
+              ActionPushNative::InternalServerError
+            end
+
+          raise error_class.new(reason, service: :apns, status: status, reason: reason,
+            retry_after: response.headers["retry-after"])
         end
     end
   end

--- a/lib/action_push_native/service/fcm.rb
+++ b/lib/action_push_native/service/fcm.rb
@@ -71,31 +71,42 @@ module ActionPushNative
 
         def handle_fcm_error(response)
           status = response.status
-          reason = \
+          error = \
             begin
-              JSON.parse(response.body.to_s).dig("error", "message")
+              JSON.parse(response.body.to_s)["error"]
             rescue JSON::ParserError
-              response.body.to_s
+              nil
+            end
+          message = error ? error["message"] : response.body.to_s
+
+          Rails.logger.error("FCM response error #{status}: #{message}")
+
+          error_class = \
+            case
+            when message =~ /message is too big/i
+              ActionPushNative::PayloadTooLargeError
+            when status == 400
+              ActionPushNative::BadRequestError
+            when status == 404
+              ActionPushNative::TokenError
+            when status.in?([ 401, 403 ])
+              ActionPushNative::ForbiddenError
+            when status == 429
+              ActionPushNative::TooManyRequestsError
+            when status == 503
+              ActionPushNative::ServiceUnavailableError
+            else
+              ActionPushNative::InternalServerError
             end
 
-          Rails.logger.error("FCM response error #{status}: #{reason}")
+          raise error_class.new(message, service: :fcm, status: error&.fetch("status", nil) || status,
+            reason: error_info_reason_from(error), retry_after: response.headers["retry-after"])
+        end
 
-          case
-          when reason =~ /message is too big/i
-            raise ActionPushNative::PayloadTooLargeError, reason
-          when status == 400
-            raise ActionPushNative::BadRequestError, reason
-          when status == 404
-            raise ActionPushNative::TokenError, reason
-          when status.in?([ 401, 403 ])
-            raise ActionPushNative::ForbiddenError, reason
-          when status == 429
-            raise ActionPushNative::TooManyRequestsError, reason
-          when status == 503
-            raise ActionPushNative::ServiceUnavailableError, reason
-          else
-            raise ActionPushNative::InternalServerError, reason
-          end
+        # The bounded, machine-readable token lives in the google.rpc.ErrorInfo
+        # detail (QUOTA_EXCEEDED, UNREGISTERED, ...); the message is free-form.
+        def error_info_reason_from(error)
+          Array(error&.fetch("details", nil)).filter_map { |detail| detail["reason"] }.first
         end
     end
   end

--- a/lib/action_push_native/service/fcm.rb
+++ b/lib/action_push_native/service/fcm.rb
@@ -4,6 +4,7 @@ module ActionPushNative
   module Service
     class Fcm
       include NetworkErrorHandling
+      prepend Instrumentation
 
       def initialize(config)
         @config = config

--- a/lib/action_push_native/service/instrumentation.rb
+++ b/lib/action_push_native/service/instrumentation.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ActionPushNative
+  module Service
+    # Instruments every provider round trip, token refresh included, as a
+    # push.action_push_native event. Prepended so it wraps each service's
+    # own push.
+    module Instrumentation
+      def push(notification)
+        ActiveSupport::Notifications.instrument "push.action_push_native",
+          service: service_name, device_token: notification.token do |payload|
+          super
+        rescue ActionPushNative::Error => error
+          payload[:status] = error.status
+          payload[:reason] = error.reason
+          payload[:retry_after] = error.retry_after
+          raise
+        end
+      end
+
+      private
+        def service_name
+          self.class.name.demodulize.underscore.to_sym
+        end
+    end
+  end
+end

--- a/lib/action_push_native/service/network_error_handling.rb
+++ b/lib/action_push_native/service/network_error_handling.rb
@@ -4,18 +4,18 @@ module ActionPushNative::Service::NetworkErrorHandling
   def handle_network_error(error)
     case error
     when HTTPX::PoolTimeoutError
-      raise ActionPushNative::ConnectionPoolTimeoutError, error.message
+      raise ActionPushNative::ConnectionPoolTimeoutError, error.message, cause: error
     when Errno::ETIMEDOUT, HTTPX::TimeoutError
-      raise ActionPushNative::TimeoutError, error.message
+      raise ActionPushNative::TimeoutError, error.message, cause: error
     when Errno::ECONNRESET, Errno::ECONNABORTED, Errno::ECONNREFUSED, Errno::EHOSTUNREACH,
       SocketError, IOError, EOFError, Errno::EPIPE, Errno::EINVAL, HTTPX::ConnectionError,
       HTTPX::TLSError, HTTPX::Connection::HTTP2::Error
-      raise ActionPushNative::ConnectionError, error.message
+      raise ActionPushNative::ConnectionError, error.message, cause: error
     when OpenSSL::SSL::SSLError
       if error.message.include?("SSL_connect")
-        raise ActionPushNative::ConnectionError, error.message
+        raise ActionPushNative::ConnectionError, error.message, cause: error
       else
-        raise
+        raise error
       end
     end
   end

--- a/test/jobs/action_push_native/notification_job_test.rb
+++ b/test/jobs/action_push_native/notification_job_test.rb
@@ -23,6 +23,24 @@ module ActionPushNative
       assert_enqueued_jobs 0, only: ActionPushNative::NotificationJob
     end
 
+    test "a provider Retry-After floors the backoff delay" do
+      device = action_push_native_devices(:iphone)
+      Notification.any_instance.stubs(:deliver_to).raises(TooManyRequestsError.new("TooManyRequests", retry_after: 600))
+
+      ActionPushNative::NotificationJob.perform_later("ApplicationPushNotification", @notification_attributes, device)
+      perform_enqueued_jobs only: ActionPushNative::NotificationJob
+      assert_wait 600
+    end
+
+    test "a Retry-After shorter than the backoff delay defers to the ladder" do
+      device = action_push_native_devices(:iphone)
+      Notification.any_instance.stubs(:deliver_to).raises(TooManyRequestsError.new("TooManyRequests", retry_after: 5))
+
+      ActionPushNative::NotificationJob.perform_later("ApplicationPushNotification", @notification_attributes, device)
+      perform_enqueued_jobs only: ActionPushNative::NotificationJob
+      assert_wait 1.minute
+    end
+
     test "BadDeviceTopic errors are discarded" do
       device = action_push_native_devices(:iphone)
       Notification.any_instance.stubs(:deliver_to).raises(BadDeviceTopicError)

--- a/test/lib/action_push_native/errors_test.rb
+++ b/test/lib/action_push_native/errors_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+module ActionPushNative
+  class ErrorsTest < ActiveSupport::TestCase
+    test "retry_after accepts delta-seconds, numerics, and nil" do
+      assert_equal 30, TooManyRequestsError.new(retry_after: "30").retry_after
+      assert_equal 2.5, TooManyRequestsError.new(retry_after: 2.5).retry_after
+      assert_nil TooManyRequestsError.new.retry_after
+    end
+
+    test "retry_after accepts an HTTP-date, clamping past dates to zero" do
+      freeze_time do
+        error = ServiceUnavailableError.new(retry_after: 42.seconds.from_now.httpdate)
+        assert_in_delta 42.0, error.retry_after, 1.0
+
+        assert_equal 0.0, ServiceUnavailableError.new(retry_after: 1.hour.ago.httpdate).retry_after
+      end
+    end
+
+    test "an unparseable Retry-After reads as nil" do
+      assert_nil TooManyRequestsError.new(retry_after: "soon").retry_after
+    end
+
+    test "the message stays the first positional argument, falling back to the reason" do
+      assert_equal "boom", TooManyRequestsError.new("boom", reason: "QUOTA_EXCEEDED").message
+      assert_equal "QUOTA_EXCEEDED", TooManyRequestsError.new(reason: "QUOTA_EXCEEDED").message
+    end
+  end
+end

--- a/test/lib/action_push_native/service/apns_test.rb
+++ b/test/lib/action_push_native/service/apns_test.rb
@@ -106,6 +106,31 @@ module ActionPushNative
         assert_equal 30, error.retry_after
       end
 
+      test "push instruments a push.action_push_native event" do
+        stub_request(:post, "https://api.push.apple.com/3/device/123").to_return(status: 200)
+
+        event = capture_push_event { @apns.push(@notification) }
+
+        assert_equal :apns, event.payload[:service]
+        assert_equal "123", event.payload[:device_token]
+        assert_operator event.duration, :>, 0
+      end
+
+      test "push instruments provider errors with their structured context" do
+        stub_request(:post, "https://api.push.apple.com/3/device/123").
+          to_return(status: 429, headers: { "Retry-After" => "30" }, body: { reason: "TooManyRequests" }.to_json)
+
+        event = capture_push_event do
+          assert_raises(ActionPushNative::TooManyRequestsError) { @apns.push(@notification) }
+        end
+
+        assert_equal :apns, event.payload[:service]
+        assert_equal 429, event.payload[:status]
+        assert_equal "TooManyRequests", event.payload[:reason]
+        assert_equal 30, event.payload[:retry_after]
+        assert_instance_of ActionPushNative::TooManyRequestsError, event.payload[:exception_object]
+      end
+
       test "network errors preserve the original exception as cause" do
         stub_request(:post, "https://api.push.apple.com/3/device/123").
           to_raise(Errno::ECONNRESET.new("Connection reset by peer"))
@@ -210,6 +235,12 @@ module ActionPushNative
       end
 
       private
+        def capture_push_event(&block)
+          event = nil
+          ActiveSupport::Notifications.subscribed(->(e) { event = e }, "push.action_push_native", &block)
+          event
+        end
+
         def build_notification
           ActionPushNative::Notification
             .with_apple(aps: { category: "readable" })

--- a/test/lib/action_push_native/service/apns_test.rb
+++ b/test/lib/action_push_native/service/apns_test.rb
@@ -92,6 +92,30 @@ module ActionPushNative
         assert_equal "Timed out after 5 seconds while waiting for a connection", error.message
       end
 
+      test "response errors carry structured provider context" do
+        stub_request(:post, "https://api.push.apple.com/3/device/123").
+          to_return(status: 503, headers: { "Retry-After" => "30" }, body: { reason: "ServiceUnavailable" }.to_json)
+
+        error = assert_raises ActionPushNative::ServiceUnavailableError do
+          @apns.push(@notification)
+        end
+        assert_equal "ServiceUnavailable", error.message
+        assert_equal :apns, error.service
+        assert_equal 503, error.status
+        assert_equal "ServiceUnavailable", error.reason
+        assert_equal 30, error.retry_after
+      end
+
+      test "network errors preserve the original exception as cause" do
+        stub_request(:post, "https://api.push.apple.com/3/device/123").
+          to_raise(Errno::ECONNRESET.new("Connection reset by peer"))
+
+        error = assert_raises ActionPushNative::ConnectionError do
+          @apns.push(@notification)
+        end
+        assert_instance_of Errno::ECONNRESET, error.cause
+      end
+
       test "push apns payload can be overridden" do
         @notification.apple_data = { aps: { "thread-id": "changed" } }
 

--- a/test/lib/action_push_native/service/fcm_test.rb
+++ b/test/lib/action_push_native/service/fcm_test.rb
@@ -62,6 +62,33 @@ module ActionPushNative
         end
       end
 
+      test "response errors carry structured provider context" do
+        body = \
+          {
+            error: {
+              code: 429,
+              message: "Sending limit exceeded",
+              status: "RESOURCE_EXHAUSTED",
+              details: [
+                { "@type": "type.googleapis.com/google.rpc.RetryInfo", retryDelay: "42s" },
+                { "@type": "type.googleapis.com/google.rpc.ErrorInfo", reason: "QUOTA_EXCEEDED", domain: "fcm.googleapis.com" }
+              ]
+            }
+          }
+
+        stub_request(:post, "https://fcm.googleapis.com/v1/projects/your_project_id/messages:send").
+          to_return(status: 429, headers: { "Retry-After" => "42" }, body: body.to_json)
+
+        error = assert_raises ActionPushNative::TooManyRequestsError do
+          @fcm.push(@notification)
+        end
+        assert_equal "Sending limit exceeded", error.message
+        assert_equal :fcm, error.service
+        assert_equal "RESOURCE_EXHAUSTED", error.status
+        assert_equal "QUOTA_EXCEEDED", error.reason
+        assert_equal 42, error.retry_after
+      end
+
       test "push fcm payload can be overridden" do
         @notification.google_data = { android: { collapse_key: "changed", notification: nil }, data: nil }
         payload = { message: { token: "123", android: { collapse_key: "changed", priority: "normal" } } }

--- a/test/lib/action_push_native/service/fcm_test.rb
+++ b/test/lib/action_push_native/service/fcm_test.rb
@@ -89,6 +89,24 @@ module ActionPushNative
         assert_equal 42, error.retry_after
       end
 
+      test "push instruments provider errors with their structured context" do
+        stub_request(:post, "https://fcm.googleapis.com/v1/projects/your_project_id/messages:send").
+          to_return(status: 503, headers: { "Retry-After" => "15" },
+            body: { error: { message: "Service unavailable", status: "UNAVAILABLE" } }.to_json)
+
+        event = nil
+        capture = ->(e) { event = e }
+        ActiveSupport::Notifications.subscribed(capture, "push.action_push_native") do
+          assert_raises(ActionPushNative::ServiceUnavailableError) { @fcm.push(@notification) }
+        end
+
+        assert_equal :fcm, event.payload[:service]
+        assert_equal "123", event.payload[:device_token]
+        assert_equal "UNAVAILABLE", event.payload[:status]
+        assert_equal 15, event.payload[:retry_after]
+        assert_instance_of ActionPushNative::ServiceUnavailableError, event.payload[:exception_object]
+      end
+
       test "push fcm payload can be overridden" do
         @notification.google_data = { android: { collapse_key: "changed", notification: nil }, data: nil }
         payload = { message: { token: "123", android: { collapse_key: "changed", priority: "normal" } } }


### PR DESCRIPTION
Three layered changes that surface what the providers already tell us but the gem discarded at the raise sites:

**Structured provider errors.** All errors reparent onto a new `ActionPushNative::Error` base carrying `service`, `status`, `reason`, and `retry_after`. The message stays the first positional argument (`super(message || reason)`), so existing rescuers and message matching keep working.
- APNs: numeric HTTP status + the parsed reason enum token (`TooManyRequests`, `BadDeviceToken`, …), and `Retry-After` (APNs sends it on 503).
- FCM: the `google.rpc` status token (`UNAVAILABLE`, `RESOURCE_EXHAUSTED`, …; HTTP status when the body has none) + the bounded `ErrorInfo` `reason` token (`QUOTA_EXCEEDED`, `UNREGISTERED`, …) instead of the free-form message, and `Retry-After` (FCM sends it on both 429 and 503 — the highest-value datum for a sender under pressure).
- `retry_after` is normalized to seconds, accepting delta-seconds and HTTP-date forms.
- Network errors keep the original exception as `cause` instead of losing its class in the wrapping.

Why: apps building delivery observability or adaptive backpressure currently have to sniff error message strings to tell "provider is in distress" from "this one token is throttled". The bounded tokens make that a comparison, not a regex.

**`push.action_push_native` instrumentation.** A shared `Instrumentation` module prepended around each service's `push` — the one point where notification, config, response, and error are all in scope — emits an event per provider round trip (token refresh included, so duration is the true cost). Payload: `service:`, `device_token:`, plus `status:`/`reason:`/`retry_after:` and the auto-captured `exception_object` on error.

**Retry-After honored in the retry ladder.** The 429/503/500 exponential backoff now treats a provider-mandated `retry_after` as a floor: waits still stretch exponentially, but never schedule ahead of the provider's ask. Implemented in `retry_job`, which receives `error:` from `retry_on` on every supported Rails (verified on 7.2 and current main), so no version gate is needed.

Tests cover the structured context on both services (header-carrying WebMock stubs), cause preservation, the instrumentation payload on success and error, and both sides of the floor (`Retry-After` above and below the computed backoff). README documents all three.

Running in production at Basecamp feeding provider-error backpressure; these hooks replace app-side error-string sniffing.

**Note on `network_error_handling.rb`'s SSL branch**: the non-`SSL_connect` path previously used a bare `raise`, which outside a rescue context raises `RuntimeError` rather than re-raising — it now re-raises the original `error` explicitly.