### PR TITLE
Surface FCM quota violations on throttle errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,10 +307,11 @@ provider response carry the context of that response:
 
 ```ruby
 rescue ActionPushNative::TooManyRequestsError => error
-  error.service     # :apns or :fcm
-  error.status      # APNs: HTTP status (429); FCM: google.rpc status token ("RESOURCE_EXHAUSTED")
-  error.reason      # APNs: reason token ("TooManyRequests"); FCM: ErrorInfo reason ("QUOTA_EXCEEDED")
-  error.retry_after # provider-mandated wait, in seconds, when the response carried Retry-After
+  error.service          # :apns or :fcm
+  error.status           # APNs: HTTP status (429); FCM: google.rpc status token ("RESOURCE_EXHAUSTED")
+  error.reason           # APNs: reason token ("TooManyRequests"); FCM: ErrorInfo reason ("QUOTA_EXCEEDED")
+  error.retry_after      # provider-mandated wait, in seconds, when the response carried Retry-After
+  error.quota_violations # FCM only: google.rpc.QuotaFailure violations, when the response included them
 end
 ```
 

--- a/lib/action_push_native/errors.rb
+++ b/lib/action_push_native/errors.rb
@@ -5,15 +5,17 @@ require "time"
 module ActionPushNative
   # Base class for Action Push Native errors. Errors raised from a provider
   # response carry structured context: the service that answered, the
-  # provider's status and reason tokens, and any Retry-After it mandated.
+  # provider's status and reason tokens, any Retry-After it mandated, and
+  # any quota violations it reported (FCM).
   class Error < StandardError
-    attr_reader :service, :status, :reason, :retry_after
+    attr_reader :service, :status, :reason, :retry_after, :quota_violations
 
-    def initialize(message = nil, service: nil, status: nil, reason: nil, retry_after: nil)
+    def initialize(message = nil, service: nil, status: nil, reason: nil, retry_after: nil, quota_violations: nil)
       @service = service
       @status = status
       @reason = reason
       @retry_after = retry_after_in_seconds(retry_after)
+      @quota_violations = normalized_quota_violations(quota_violations)
       super(message || reason)
     end
 
@@ -30,6 +32,12 @@ module ActionPushNative
         end
       rescue ArgumentError
         nil
+      end
+
+      # Quota violations arrive as raw google.rpc.QuotaFailure violation hashes
+      # and pass through losslessly.
+      def normalized_quota_violations(violations)
+        Array(violations).grep(Hash).map(&:freeze).freeze
       end
   end
 

--- a/lib/action_push_native/service/fcm.rb
+++ b/lib/action_push_native/service/fcm.rb
@@ -101,13 +101,26 @@ module ActionPushNative
             end
 
           raise error_class.new(message, service: :fcm, status: error&.fetch("status", nil) || status,
-            reason: error_info_reason_from(error), retry_after: response.headers["retry-after"])
+            reason: error_info_reason_from(error), retry_after: response.headers["retry-after"],
+            quota_violations: quota_violations_from(error))
         end
 
         # The bounded, machine-readable token lives in the google.rpc.ErrorInfo
         # detail (QUOTA_EXCEEDED, UNREGISTERED, ...); the message is free-form.
         def error_info_reason_from(error)
-          Array(error&.fetch("details", nil)).filter_map { |detail| detail["reason"] }.first
+          details_of_type(error, "type.googleapis.com/google.rpc.ErrorInfo").filter_map { |detail| detail["reason"] }.first
+        end
+
+        # QuotaFailure details enumerate the limits that were hit, distinguishing
+        # per-device and per-topic throttling from project-wide quota.
+        def quota_violations_from(error)
+          details_of_type(error, "type.googleapis.com/google.rpc.QuotaFailure").flat_map do |detail|
+            detail["violations"].is_a?(Array) ? detail["violations"] : []
+          end
+        end
+
+        def details_of_type(error, type)
+          Array(error&.fetch("details", nil)).select { |detail| detail.is_a?(Hash) && detail["@type"] == type }
         end
     end
   end

--- a/test/lib/action_push_native/errors_test.rb
+++ b/test/lib/action_push_native/errors_test.rb
@@ -25,5 +25,18 @@ module ActionPushNative
       assert_equal "boom", TooManyRequestsError.new("boom", reason: "QUOTA_EXCEEDED").message
       assert_equal "QUOTA_EXCEEDED", TooManyRequestsError.new(reason: "QUOTA_EXCEEDED").message
     end
+
+    test "quota_violations defaults to an empty array" do
+      assert_equal [], TooManyRequestsError.new.quota_violations
+    end
+
+    test "quota_violations keeps hash entries and drops the rest, frozen" do
+      violation = { "subject" => "device:1", "description" => "rate limited" }
+      error = TooManyRequestsError.new(quota_violations: [ violation, "junk", nil ])
+
+      assert_equal [ violation ], error.quota_violations
+      assert error.quota_violations.frozen?
+      assert error.quota_violations.first.frozen?
+    end
   end
 end

--- a/test/lib/action_push_native/service/fcm_test.rb
+++ b/test/lib/action_push_native/service/fcm_test.rb
@@ -71,7 +71,10 @@ module ActionPushNative
               status: "RESOURCE_EXHAUSTED",
               details: [
                 { "@type": "type.googleapis.com/google.rpc.RetryInfo", retryDelay: "42s" },
-                { "@type": "type.googleapis.com/google.rpc.ErrorInfo", reason: "QUOTA_EXCEEDED", domain: "fcm.googleapis.com" }
+                { "@type": "type.googleapis.com/google.rpc.ErrorInfo", reason: "QUOTA_EXCEEDED", domain: "fcm.googleapis.com" },
+                { "@type": "type.googleapis.com/google.rpc.QuotaFailure", violations: [
+                  { subject: "project:123456", description: "Message rate limit exceeded for device" }
+                ] }
               ]
             }
           }
@@ -87,6 +90,62 @@ module ActionPushNative
         assert_equal "RESOURCE_EXHAUSTED", error.status
         assert_equal "QUOTA_EXCEEDED", error.reason
         assert_equal 42, error.retry_after
+        assert_equal [ { "subject" => "project:123456", "description" => "Message rate limit exceeded for device" } ],
+          error.quota_violations
+      end
+
+      test "quota violations concatenate across QuotaFailure details" do
+        body = \
+          {
+            error: {
+              code: 429,
+              message: "Sending limit exceeded",
+              status: "RESOURCE_EXHAUSTED",
+              details: [
+                { "@type": "type.googleapis.com/google.rpc.QuotaFailure", violations: [ { subject: "device:1" } ] },
+                { "@type": "type.googleapis.com/google.rpc.QuotaFailure", violations: [ { subject: "device:2" } ] }
+              ]
+            }
+          }
+
+        stub_request(:post, "https://fcm.googleapis.com/v1/projects/your_project_id/messages:send").
+          to_return(status: 429, body: body.to_json)
+
+        error = assert_raises ActionPushNative::TooManyRequestsError do
+          @fcm.push(@notification)
+        end
+        assert_equal [ { "subject" => "device:1" }, { "subject" => "device:2" } ], error.quota_violations
+      end
+
+      test "malformed error details read as no quota violations" do
+        body = \
+          {
+            error: {
+              code: 429,
+              message: "Sending limit exceeded",
+              status: "RESOURCE_EXHAUSTED",
+              details: [
+                "not a hash",
+                { "@type": "type.googleapis.com/google.rpc.QuotaFailure", violations: "not an array" }
+              ]
+            }
+          }
+
+        stub_request(:post, "https://fcm.googleapis.com/v1/projects/your_project_id/messages:send").
+          to_return(status: 429, body: body.to_json)
+
+        error = assert_raises ActionPushNative::TooManyRequestsError do
+          @fcm.push(@notification)
+        end
+        assert_equal [], error.quota_violations
+
+        stub_request(:post, "https://fcm.googleapis.com/v1/projects/your_project_id/messages:send").
+          to_return(status: 429, body: { error: { message: "Sending limit exceeded", status: "RESOURCE_EXHAUSTED" } }.to_json)
+
+        error = assert_raises ActionPushNative::TooManyRequestsError do
+          @fcm.push(@notification)
+        end
+        assert_equal [], error.quota_violations
       end
 
       test "push instruments provider errors with their structured context" do


### PR DESCRIPTION
## Motivation

#128 extracted the bounded ErrorInfo `reason` from FCM error details onto structured errors. On throttle responses that token is `QUOTA_EXCEEDED` regardless of *which* limit was hit — a device message rate, a topic message rate, or project-wide quota. When FCM includes `google.rpc.QuotaFailure` details in the response, their violations are the data that distinguishes those cases, and the gem currently discards them — leaving apps that want to treat per-recipient throttling differently from project-wide quota to regex the free-form error message.

## What this does

- `ActionPushNative::Error` gains `quota_violations`: the raw violation hashes (`subject`, `description` today), passed through losslessly and frozen, defaulting to `[]`. No value object — Google's schema stays Google's.
- The FCM service extracts violations from `google.rpc.QuotaFailure` details at the raise site, flat-mapping across multiple QuotaFailure entries and tolerating malformed shapes (non-hash details, non-array `violations`).
- Both detail readers — the existing ErrorInfo `reason` and the new QuotaFailure violations — now select details by their `@type`, behavior-neutral for well-formed payloads.
- APNs is untouched; `quota_violations` is simply empty there.

Instrumentation consumers reach the violations through `exception_object` in the `push.action_push_native` event payload.

## Example

```ruby
rescue ActionPushNative::TooManyRequestsError => error
  error.reason           # "QUOTA_EXCEEDED"
  error.quota_violations # [{ "subject" => "...", "description" => "Message rate limit exceeded for device" }]
end
```